### PR TITLE
API fix

### DIFF
--- a/src/hooks/useComments.js
+++ b/src/hooks/useComments.js
@@ -13,7 +13,7 @@ export default function useComments(id, { reload, token }) {
 
     commentService
       .getComments(id)
-      .then(u => setComments(u.message.comments))
+      .then(u => setComments(u.comments))
       .catch(_ => {})
   }, [id, reload, token, didPersistLoad])
 


### PR DESCRIPTION
the comments being nested is a mistake and inconsistent with the API. This change is to make the client compatible with the fixed/improved formatting.